### PR TITLE
updated DMX_frame_pipeline.py to match frame_pipeline.py

### DIFF
--- a/src/DMX_frame_pipeline.py
+++ b/src/DMX_frame_pipeline.py
@@ -1,12 +1,4 @@
 # src/DMX_frame_pipeline.py
-# Daniel Saravia
-# STG-452: Capstone Project II
-# March 28, 2025
-# I used source code from the following 
-# website to complete this assignment:
-# https://chatgpt.com/share/67a17189-ca30-800e-858d-aac289e6cb56
-
-
 import concurrent.futures
 import logging
 import cv2 as cv
@@ -15,67 +7,54 @@ import websocket
 
 from ai_model_interface import AIModelInterface
 from detection_processor import DetectionProcessor
-from frame_processor import FrameProcessor
 from tracking_system import TrackingSystem
 from video_stream_manager import VideoStreamManager
 
 class FramePipeline:
-    """A pipeline that captures frames from a video stream, processes them, 
-    runs YOLO + detection filtering, then tracks objects over time.
-    Additionally, it uses the latest detection's centroid to control a moving head light via DMX."""
-    
+    """A pipeline that captures frames from a video stream, runs AI detection,
+    filters detections, tracks objects over time, and uses the latest detection's
+    centroid to control a moving head light via DMX."""
+
     def __init__(
         self,
-        capture_device=1,
-        frame_width=1920,
-        frame_height=1080,
-        target_width=1920,
-        target_height=1080,
         model_path="drone_detector_12n.pt",
         confidence_threshold=0.5,
         detection_processor=None,
         tracking_system=None
     ):
-        # Video and processing setup.
-        self.video_stream = VideoStreamManager(
-            capture_device=capture_device, 
-            frame_width=frame_width, 
-            frame_height=frame_height
-        )
-        self.frame_processor = FrameProcessor(
-            target_width=target_width, 
-            target_height=target_height
-        )
+        # Set up the video stream manager.
+        self.video_stream = VideoStreamManager()
+        # Set up the AI model interface.
         self.ai_model_interface = AIModelInterface(
             model_path=model_path,
             confidence_threshold=confidence_threshold
         )
+        # Use a provided detection processor or create one with default parameters.
         self.detection_processor = detection_processor or DetectionProcessor(
             target_classes=None
         )
+        # Use a provided tracking system or create one with default parameters.
         self.tracking_system = tracking_system or TrackingSystem(
-            max_disappeared=50, 
+            max_disappeared=50,
             max_distance=50
         )
-        
-        # Initialize DMX control parameters to 0.
-        # Pan: 0° to 540° (DMX 0-255), Tilt: 0° to 205° (DMX 0-255).
-        # Starting at 0 degrees for both.
-        self.current_pan = 0.0    
-        self.current_tilt = 0.0   
-        
-        # Proportional gain factors (tune these for your system)
-        # Lower gains help reduce aggressive corrections.
-        self.k_pan = 0.005    # reduced pan gain: degrees per pixel error in x
-        self.k_tilt = 0.005    # tilt gain remains the same
-        
-        # Maximum allowed change per update (damping factor)
-        self.max_delta_pan = 2.5   # reduced maximum degrees change per frame for pan
-        self.max_delta_tilt = 2.5   # maximum degrees change per frame for tilt
-        
+
+        # Initialize DMX control parameters.
+        # Pan: 0° to 540° (mapped to DMX 0-255), Tilt: 0° to 205° (mapped to DMX 0-255).
+        self.current_pan = 0.0
+        self.current_tilt = 0.0
+
+        # Proportional gain factors (tune these for your system).
+        self.k_pan = 0.005    # Pan gain: degrees per pixel error in x.
+        self.k_tilt = 0.005   # Tilt gain: degrees per pixel error in y.
+
+        # Maximum allowed change per update (damping factor).
+        self.max_delta_pan = 2.5   # Maximum degrees change per frame for pan.
+        self.max_delta_tilt = 2.5  # Maximum degrees change per frame for tilt.
+
         # Initialize DMX connection via QLC+ WebSocket.
         self.init_dmx_connection()
-    
+
     def init_dmx_connection(self):
         """Initializes the WebSocket connection to the QLC+ DMX controller."""
         try:
@@ -119,10 +98,12 @@ class FramePipeline:
             thickness = 4
             (text_width, text_height), baseline = cv.getTextSize(label, font, font_scale, thickness)
             margin = 5
-            cv.rectangle(frame,
-                         (x_min, y_min - text_height - baseline - margin),
-                         (x_min + text_width, y_min),
-                         (0, 0, 0), -1)
+            cv.rectangle(
+                frame,
+                (x_min, y_min - text_height - baseline - margin),
+                (x_min + text_width, y_min),
+                (0, 0, 0), -1
+            )
             cv.putText(frame, label, (x_min, y_min - margin), font, font_scale, (0, 255, 0), thickness)
 
     def draw_tracked_objects(self, frame, tracked_objects):
@@ -134,29 +115,26 @@ class FramePipeline:
             cv.rectangle(frame, (x_min, y_min), (x_max, y_max), (0, 255, 0), 2)
             cv.circle(frame, (int(cx), int(cy)), 4, (0, 255, 0), -1)
 
-    def update_dmx_control(self, centroid, frame_dims):
+    def update_dmx_control(self, centroid, frame):
         """Calculates the error between the centroid and the frame center,
         computes a damped adjustment, updates the pan and tilt angles,
-        and sends new DMX values."""
-        frame_width, frame_height = frame_dims
+        and sends new DMX values.
+
+        This version retrieves the frame dimensions using the frame's shape.
+        """
+        # Obtain frame dimensions from the frame itself.
+        frame_height, frame_width = frame.shape[:2]
         center_x, center_y = frame_width / 2, frame_height / 2
-        error_x = centroid[0] - center_x  # positive if object is to the right
-        error_y = centroid[1] - center_y  # positive if object is below center
+        error_x = centroid[0] - center_x  # positive if object is to the right.
+        error_y = centroid[1] - center_y  # positive if object is below center.
 
         # Compute raw adjustments based on proportional gain.
         delta_pan = self.k_pan * error_x
         delta_tilt = self.k_tilt * error_y
 
         # Clamp the adjustments to the maximum allowed change per update.
-        if delta_pan > self.max_delta_pan:
-            delta_pan = self.max_delta_pan
-        elif delta_pan < -self.max_delta_pan:
-            delta_pan = -self.max_delta_pan
-
-        if delta_tilt > self.max_delta_tilt:
-            delta_tilt = self.max_delta_tilt
-        elif delta_tilt < -self.max_delta_tilt:
-            delta_tilt = -self.max_delta_tilt
+        delta_pan = max(-self.max_delta_pan, min(delta_pan, self.max_delta_pan))
+        delta_tilt = max(-self.max_delta_tilt, min(delta_tilt, self.max_delta_tilt))
 
         # Update the current angles.
         self.current_pan -= delta_pan
@@ -175,13 +153,13 @@ class FramePipeline:
         self.send_dmx_value(3, dmx_tilt)
 
     def run(self):
-        """Captures frames, runs preprocessing + AI + detection processing,
-        updates the tracking system, draws annotations, and controls the moving head light."""
+        """Captures frames, runs AI prediction, processes detections,
+        updates the tracking system, draws annotations, and controls the moving head light via DMX."""
         try:
             with self.video_stream as stream, concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-                cv.namedWindow("Mini C-RAM View", cv.WINDOW_NORMAL)
-                cv.resizeWindow("Mini C-RAM View", 800, 600)
-                cv.setWindowProperty("Mini C-RAM View", cv.WND_PROP_TOPMOST, 1)
+                cv.namedWindow("AIegis Beam View", cv.WINDOW_NORMAL)
+                cv.resizeWindow("AIegis Beam View", 800, 600)
+                cv.setWindowProperty("AIegis Beam View", cv.WND_PROP_TOPMOST, 1)
 
                 while True:
                     frame = stream.get_frame()
@@ -189,14 +167,15 @@ class FramePipeline:
                         logging.warning("No frame captured. Exiting the pipeline.")
                         break
 
-                    # Preprocess frame and run AI model.
-                    processed_frame = self.frame_processor.preprocess_frame(frame)
-                    future = executor.submit(self.ai_model_interface.predict, processed_frame[0])
+                    # Run the AI model prediction asynchronously.
+                    future = executor.submit(self.ai_model_interface.predict, frame)
                     raw_detections = future.result()
+
+                    # Process detections and update tracking.
                     processed_detections = self.detection_processor.process_detections(raw_detections)
                     tracked_objects = self.tracking_system.update(processed_detections)
 
-                    # Draw detection and tracking annotations.
+                    # Draw the detection bounding boxes and tracked objects.
                     self.draw_detections(frame, processed_detections)
                     self.draw_tracked_objects(frame, tracked_objects)
 
@@ -204,15 +183,16 @@ class FramePipeline:
                     if processed_detections:
                         latest_det = processed_detections[-1]
                         centroid = latest_det["centroid"]
-                        self.update_dmx_control(centroid, (stream.frame_width, stream.frame_height))
+                        # Pass the frame itself to update_dmx_control.
+                        self.update_dmx_control(centroid, frame)
 
-                    cv.imshow("Mini C-RAM View", frame)
+                    cv.imshow("AIegis Beam View", frame)
                     if cv.waitKey(1) & 0xFF == ord('q'):
                         break
-        
+
         except Exception as e:
             logging.error(f"Error in FramePipeline run: {e}")
-        
+
         finally:
             self.video_stream.release_stream()
             cv.destroyAllWindows()

--- a/src/run.py
+++ b/src/run.py
@@ -3,29 +3,24 @@ import logging
 from DMX_frame_pipeline import FramePipeline
 
 def main():
-    # Configure logging to output messages with timestamp and level.
+    # Configure logging with timestamps and log levels.
     logging.basicConfig(
-        level=logging.INFO, 
+        level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s"
     )
-    
+
     try:
-        # Initialize the FramePipeline with required parameters.
+        # Initialize the DMX FramePipeline with the updated parameters.
         pipeline = FramePipeline(
-            capture_device=0,
-            frame_width=1920,
-            frame_height=1080,
-            target_width=1920,
-            target_height=1080,
             model_path="drone_detector_12n.pt",
             confidence_threshold=0.5
         )
-        
         # Run the pipeline continuously.
         pipeline.run()
-        
+
     except Exception as e:
         logging.error(f"FramePipeline execution failed: {e}")
 
 if __name__ == "__main__":
     main()
+

--- a/src/video_stream_manager.py
+++ b/src/video_stream_manager.py
@@ -12,7 +12,7 @@ import cv2 as cv # For computer vision using OpenCV
 class VideoStreamManager:
     """Manages video stream capture and processing."""
 
-    def __init__(self, capture_device=1, max_queue_size=10):
+    def __init__(self, capture_device=0, max_queue_size=10):
         """Initialize with capture device index and frame queue size."""
         self.capture_device = capture_device
         self.capture = None


### PR DESCRIPTION
Summary
Fix the error by updating DMX control to use frame dimensions directly.

Changes
Removed cap Dependency: Replaced calls to cap.get(cv.PROP_FRAME_WIDTH) and cap.get(cv.PROP_FRAME_HEIGHT) with dimensions from frame.shape.

Updated update_dmx_control: Now accepts the frame directly, ensuring accurate center calculations.

Adjusted run() Method: Passes the frame to update_dmx_control instead of the non-existent stream.cap.

Rationale
This change resolves the error 'VideoStreamManager' object has no attribute 'cap' and ensures that DMX control calculations are based on the actual frame dimensions.